### PR TITLE
Clear on screen win/draw/lose counters on reset.

### DIFF
--- a/menace.js
+++ b/menace.js
@@ -184,6 +184,10 @@ function do_win(who_wins){
 
 function reset_menace(){
     wins_each=Array(0,0,0)
+    for (var i = 1; i <= 3; i++) {
+        document.getElementById("dis" + i).innerHTML = wins_each[i - 1]
+    }
+
     orderedBoxes = Array()
 
     // First moves


### PR DESCRIPTION
I noticed it looked like the win/lose/draw counts weren't resetting when I clicked on "Update and reset menace", but it turns out only the on screen text wasn't being updated on reset, so I fixed it.